### PR TITLE
do not use ellipsis for dropdown menu

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -755,8 +755,6 @@ a.status__content__spoiler-link {
     background: $color2;
     color: $color1;
     overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
 
     &:focus {
       outline: 0;


### PR DESCRIPTION
長いアカウント名の場合 `ブロック/通報する` が省略記号 `...` になるのを回避したい

![image](https://cloud.githubusercontent.com/assets/1737140/25180708/f99afe24-2549-11e7-84e1-c2a1403e2bce.png)
