### PR TITLE
画面の横幅が十分に広いとき、UIの4カラムを画面サイズ一杯に4分割されるようリフローする変更

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -876,6 +876,7 @@ a.status__content__spoiler-link {
   }
 
   .column, .drawer {
+    width : 25% ;
     flex: 0 0 auto;
     padding: 10px;
     padding-left: 5px;
@@ -897,7 +898,7 @@ a.status__content__spoiler-link {
   }
 
   .column, .drawer {
-    width: 350px;
+    width: 25%;
     border-radius: 4px;
     height: 90vh;
     margin-top: 5vh;


### PR DESCRIPTION
画面の横幅が十分に広いとき、UIの4カラムを画面サイズ一杯に4分割されるようリフローする変更

テストしてないけど多分動くと思うよ。

@media screen and (min-width: 1025px)と@media screen and (min-width: 2560px)
の
.column, .drawer
を
width : 25% ;
にした。