### PR TITLE
Add RPG Atsumaru content link to nicolinks

### DIFF
--- a/app/models/nico_link.rb
+++ b/app/models/nico_link.rb
@@ -2,6 +2,7 @@
 
 class NicoLink
   BASE_URI = URI.parse('https://nico.ms')
+  RPG_ATSUMARU_GAME_PAGE_BASE_URI = URI.parse('https://game.nicovideo.jp/atsumaru/games/')
 
   TEMPORAL_TYPES = %w[
     lv
@@ -11,6 +12,7 @@ class NicoLink
 
   NON_TEMPORAL_TYPES = %w[
     im
+    gm
   ].freeze
 
   NICO_ID_RE = %r{(#{[].concat(TEMPORAL_TYPES, NON_TEMPORAL_TYPES).join('|')})(\d+)}
@@ -37,7 +39,11 @@ class NicoLink
   end
 
   def to_href
-    href = BASE_URI + @nico_id
+    if @type == "gm" then
+      href = RPG_ATSUMARU_GAME_PAGE_BASE_URI + @nico_id
+    else
+      href = BASE_URI + @nico_id
+    end
     href.query = URI.encode_www_form(from: @from_sec) if time?
     href.normalize.to_s
   end

--- a/spec/models/nico_link_spec.rb
+++ b/spec/models/nico_link_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe NicoLink, type: :model do
 
         expect(subject.match('sm9#11:10')).to_not be_nil
         expect(subject.match('sm0009#11:10')).to_not be_nil
+
+        expect(subject.match('gm9#11:10')).to_not be_nil
+        expect(subject.match('gm0009#11:10')).to_not be_nil
       end
 
       it 'matches nicolinks within Japanese text' do
@@ -30,6 +33,10 @@ RSpec.describe NicoLink, type: :model do
         expect(subject.match('このsm9#11:10が好き')).to_not be_nil
         expect(subject.match('つsm90923#11:10は観たこと無いな')).to_not be_nil
         expect(subject.match('あsm9#11:10９')).to_not be_nil
+
+        expect(subject.match('このgm9#11:10が好き')).to_not be_nil
+        expect(subject.match('つgm90923#11:10は観たこと無いな')).to_not be_nil
+        expect(subject.match('あgm9#11:10９')).to_not be_nil
       end
     end
 
@@ -43,6 +50,9 @@ RSpec.describe NicoLink, type: :model do
 
         expect(subject.match('sm9')).to_not be_nil
         expect(subject.match('sm0009')).to_not be_nil
+
+        expect(subject.match('gm9')).to_not be_nil
+        expect(subject.match('gm0009')).to_not be_nil
       end
 
       it 'matches nicolinks within Japanese text' do
@@ -57,6 +67,10 @@ RSpec.describe NicoLink, type: :model do
         expect(subject.match('このsm9が好き')).to_not be_nil
         expect(subject.match('つsm90923は観たこと無いな')).to_not be_nil
         expect(subject.match('あsm9９')).to_not be_nil
+
+        expect(subject.match('このgm9が好き')).to_not be_nil
+        expect(subject.match('つgm90923は観たこと無いな')).to_not be_nil
+        expect(subject.match('あgm9９')).to_not be_nil
       end
     end
 
@@ -85,6 +99,7 @@ RSpec.describe NicoLink, type: :model do
       it 'does not add from param for non-temporal ids' do
         subject.each do |key, _|
           expect(NicoLink.new('im0139401923849', key).to_href).to eq 'https://nico.ms/im0139401923849'
+          expect(NicoLink.new('gm139401923849', key).to_href).to eq 'https://game.nicovideo.jp/atsumaru/games/gm139401923849'
         end
       end
 
@@ -126,11 +141,13 @@ RSpec.describe NicoLink, type: :model do
       let(:im) { NicoLink.new('im0139401923849') }
       let(:lv) { NicoLink.new('lv84120982743') }
       let(:sm) { NicoLink.new('sm9') }
+      let(:gm) { NicoLink.new('gm3') }
 
       it 'returns a proper href' do
         expect(im.to_href).to eq 'https://nico.ms/im0139401923849'
         expect(lv.to_href).to eq 'https://nico.ms/lv84120982743'
         expect(sm.to_href).to eq 'https://nico.ms/sm9'
+        expect(gm.to_href).to eq 'https://game.nicovideo.jp/atsumaru/games/gm3'
       end
     end
   end
@@ -160,6 +177,13 @@ RSpec.describe NicoLink, type: :model do
         a << 'あim9'
         a << 'im9９'
         a << 'あim9９'
+
+        a << 'gm9'
+        a << ' gm9'
+        a << '　gm9'
+        a << 'あgm9'
+        a << 'gm9９'
+        a << 'あgm9９'
 
         a.map { |s| NicoLink.parse s }
       end


### PR DESCRIPTION
https://github.com/dwango/mastodon/pull/19 にRPGアツマールのリンクを追加 (コンテンツ例: https://game.nicovideo.jp/atsumaru/games/gm3 )
RPGアツマールはgm(番号)表記で、時間情報は無いです
また、nico.msには非対応なので、nico.msは使わずに、直接サイトにリンクを貼りました。

メモ
テスト書いたけど、railsの使い方完全に忘れているので、動かし方が分からないです。。。
