### PR TITLE
Add manga nicolink

### DIFF
--- a/app/models/nico_link.rb
+++ b/app/models/nico_link.rb
@@ -2,6 +2,7 @@
 
 class NicoLink
   BASE_URI = URI.parse('https://nico.ms')
+  RPG_ATSUMARU_GAME_PAGE_BASE_URI = URI.parse('https://game.nicovideo.jp/atsumaru/games/')
 
   TEMPORAL_TYPES = %w[
     lv
@@ -11,6 +12,7 @@ class NicoLink
 
   NON_TEMPORAL_TYPES = %w[
     im
+    gm
   ].freeze
 
   NICO_ID_RE = %r{(#{[].concat(TEMPORAL_TYPES, NON_TEMPORAL_TYPES).join('|')})(\d+)}
@@ -37,7 +39,11 @@ class NicoLink
   end
 
   def to_href
-    href = BASE_URI + @nico_id
+    if @type == "gm" then
+      href = RPG_ATSUMARU_GAME_PAGE_BASE_URI + @nico_id
+    else
+      href = BASE_URI + @nico_id
+    end
     href.query = URI.encode_www_form(from: @from_sec) if time?
     href.normalize.to_s
   end

--- a/app/models/nico_link.rb
+++ b/app/models/nico_link.rb
@@ -13,6 +13,7 @@ class NicoLink
   NON_TEMPORAL_TYPES = %w[
     im
     gm
+    mg
   ].freeze
 
   NICO_ID_RE = %r{(#{[].concat(TEMPORAL_TYPES, NON_TEMPORAL_TYPES).join('|')})(\d+)}

--- a/spec/models/nico_link_spec.rb
+++ b/spec/models/nico_link_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe NicoLink, type: :model do
 
         expect(subject.match('sm9#11:10')).to_not be_nil
         expect(subject.match('sm0009#11:10')).to_not be_nil
+
+        expect(subject.match('gm9#11:10')).to_not be_nil
+        expect(subject.match('gm0009#11:10')).to_not be_nil
       end
 
       it 'matches nicolinks within Japanese text' do
@@ -30,6 +33,10 @@ RSpec.describe NicoLink, type: :model do
         expect(subject.match('このsm9#11:10が好き')).to_not be_nil
         expect(subject.match('つsm90923#11:10は観たこと無いな')).to_not be_nil
         expect(subject.match('あsm9#11:10９')).to_not be_nil
+
+        expect(subject.match('このgm9#11:10が好き')).to_not be_nil
+        expect(subject.match('つgm90923#11:10は観たこと無いな')).to_not be_nil
+        expect(subject.match('あgm9#11:10９')).to_not be_nil
       end
     end
 
@@ -43,6 +50,9 @@ RSpec.describe NicoLink, type: :model do
 
         expect(subject.match('sm9')).to_not be_nil
         expect(subject.match('sm0009')).to_not be_nil
+
+        expect(subject.match('gm9')).to_not be_nil
+        expect(subject.match('gm0009')).to_not be_nil
       end
 
       it 'matches nicolinks within Japanese text' do
@@ -57,6 +67,10 @@ RSpec.describe NicoLink, type: :model do
         expect(subject.match('このsm9が好き')).to_not be_nil
         expect(subject.match('つsm90923は観たこと無いな')).to_not be_nil
         expect(subject.match('あsm9９')).to_not be_nil
+
+        expect(subject.match('このgm9が好き')).to_not be_nil
+        expect(subject.match('つgm90923は観たこと無いな')).to_not be_nil
+        expect(subject.match('あgm9９')).to_not be_nil
       end
     end
 
@@ -85,6 +99,7 @@ RSpec.describe NicoLink, type: :model do
       it 'does not add from param for non-temporal ids' do
         subject.each do |key, _|
           expect(NicoLink.new('im0139401923849', key).to_href).to eq 'https://nico.ms/im0139401923849'
+          expect(NicoLink.new('gm139401923849', key).to_href).to eq 'https://game.nicovideo.jp/atsumaru/games/gm139401923849'
         end
       end
 
@@ -126,11 +141,13 @@ RSpec.describe NicoLink, type: :model do
       let(:im) { NicoLink.new('im0139401923849') }
       let(:lv) { NicoLink.new('lv84120982743') }
       let(:sm) { NicoLink.new('sm9') }
+      let(:gm) { NicoLink.new('gm3') }
 
       it 'returns a proper href' do
         expect(im.to_href).to eq 'https://nico.ms/im0139401923849'
         expect(lv.to_href).to eq 'https://nico.ms/lv84120982743'
         expect(sm.to_href).to eq 'https://nico.ms/sm9'
+        expect(gm.to_href).to eq 'https://game.nicovideo.jp/atsumaru/games/gm3'
       end
     end
   end
@@ -160,6 +177,13 @@ RSpec.describe NicoLink, type: :model do
         a << 'あim9'
         a << 'im9９'
         a << 'あim9９'
+
+        a << 'gm9'
+        a << ' gm9'
+        a << '　gm9'
+        a << 'あgm9'
+        a << 'gm9９'
+        a << 'あgm9９'
 
         a.map { |s| NicoLink.parse s }
       end

--- a/spec/models/nico_link_spec.rb
+++ b/spec/models/nico_link_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe NicoLink, type: :model do
         expect(subject.match('im9#11:10')).to_not be_nil
         expect(subject.match('im0009#11:10')).to_not be_nil
 
+        expect(subject.match('mg9#11:10')).to_not be_nil
+        expect(subject.match('mg0009#11:10')).to_not be_nil
+
         expect(subject.match('lv9#11:10')).to_not be_nil
         expect(subject.match('lv0009#11:10')).to_not be_nil
 
@@ -25,6 +28,10 @@ RSpec.describe NicoLink, type: :model do
         expect(subject.match('このim9#11:10が好き')).to_not be_nil
         expect(subject.match('つim90923#11:10は観たこと無いな')).to_not be_nil
         expect(subject.match('あim9#11:10９')).to_not be_nil
+
+        expect(subject.match('このmg9#11:10が好き')).to_not be_nil
+        expect(subject.match('つmg90923#11:10は観たこと無いな')).to_not be_nil
+        expect(subject.match('あmg9#11:10９')).to_not be_nil
 
         expect(subject.match('このlv9#11:10が好き')).to_not be_nil
         expect(subject.match('つlv90923#11:10は観たこと無いな')).to_not be_nil
@@ -45,6 +52,9 @@ RSpec.describe NicoLink, type: :model do
         expect(subject.match('im9')).to_not be_nil
         expect(subject.match('im0009')).to_not be_nil
 
+        expect(subject.match('mg9')).to_not be_nil
+        expect(subject.match('mg0009')).to_not be_nil
+
         expect(subject.match('lv9')).to_not be_nil
         expect(subject.match('lv0009')).to_not be_nil
 
@@ -59,6 +69,10 @@ RSpec.describe NicoLink, type: :model do
         expect(subject.match('このim9が好き')).to_not be_nil
         expect(subject.match('つim90923は観たこと無いな')).to_not be_nil
         expect(subject.match('あim9９')).to_not be_nil
+
+        expect(subject.match('このmg9が好き')).to_not be_nil
+        expect(subject.match('つmg90923は観たこと無いな')).to_not be_nil
+        expect(subject.match('あmg9９')).to_not be_nil
 
         expect(subject.match('このlv9が好き')).to_not be_nil
         expect(subject.match('つlv90923は観たこと無いな')).to_not be_nil
@@ -139,12 +153,14 @@ RSpec.describe NicoLink, type: :model do
 
     context 'without time' do
       let(:im) { NicoLink.new('im0139401923849') }
+      let(:im) { NicoLink.new('mg0139401923849') }      
       let(:lv) { NicoLink.new('lv84120982743') }
       let(:sm) { NicoLink.new('sm9') }
       let(:gm) { NicoLink.new('gm3') }
 
       it 'returns a proper href' do
         expect(im.to_href).to eq 'https://nico.ms/im0139401923849'
+        expect(mg.to_href).to eq 'https://nico.ms/mg0139401923849'
         expect(lv.to_href).to eq 'https://nico.ms/lv84120982743'
         expect(sm.to_href).to eq 'https://nico.ms/sm9'
         expect(gm.to_href).to eq 'https://game.nicovideo.jp/atsumaru/games/gm3'
@@ -177,6 +193,13 @@ RSpec.describe NicoLink, type: :model do
         a << 'あim9'
         a << 'im9９'
         a << 'あim9９'
+
+        a << 'mg9'
+        a << ' mg9'
+        a << '　mg9'
+        a << 'あmg9'
+        a << 'mg9９'
+        a << 'あmg9９'
 
         a << 'gm9'
         a << ' gm9'


### PR DESCRIPTION
静画（マンガ）の `mg` に対応させました。

#36 とコンフリクトしそうなので一旦コミットを重ねて pull request を作りました。
差分は b12e6a7 をみていただければ。

#36 が merge された後に rebase します。
