### PR TITLE
fix nicoru copyable

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,4 +12,5 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require nicoru
 //= require components

--- a/app/assets/javascripts/application_public.js
+++ b/app/assets/javascripts/application_public.js
@@ -1,5 +1,6 @@
 //= require jquery
 //= require jquery_ujs
+//= require nicoru
 //= require extras
 //= require best_in_place
 

--- a/app/assets/javascripts/components/emoji.jsx
+++ b/app/assets/javascripts/components/emoji.jsx
@@ -30,9 +30,9 @@ const shortnameToImage = str => str.replace(emojione.regShortNames, shortname =>
   return `<img draggable="false" class="emojione" alt="${alt}" src="/emoji/${unicode}.svg" />`;
 });
 
-const nicoruToImage = str => str.replace(/:nicoru(\d*):/g, (nicoru, deg) => {
+const nicoruToImage = str => str.replace(/:nicoru(\d*):/g, (match, deg) => {
   deg = deg ? deg : 0;
-  return `<i class="fa-nicoru" style="transform:rotate(${deg}deg);"></i>`;
+  return `<img draggable="false" class="emojione" alt="${match}" src="${NicoruImages.main}" style="transform:rotate(${deg}deg);" />`;
 });
 
 export default function emojify(text) {

--- a/app/assets/javascripts/nicoru.js.erb
+++ b/app/assets/javascripts/nicoru.js.erb
@@ -1,0 +1,6 @@
+window.NicoruImages = {
+  main: "<%= asset_path('nicoru.svg') %>",
+  column: "<%= asset_path('nicoru-column.svg') %>",
+  status: "<%= asset_path('nicoru-status.svg') %>",
+  detailed: "<%= asset_path('nicoru-detailed.svg') %>"
+};


### PR DESCRIPTION
通常の絵文字と同様に、imgタグとalt属性によってニコるを選択＆コピペ可能に改善。

asset_pathでのsvgパス解決をするためにerbとして記述。
`import nicoru from './nicoru';` したかったのですがうまく解決できなかったので `//= require` で解決させました。