### PR TITLE
Fix to star to nicoru on getting-started.

### DIFF
--- a/app/javascript/mastodon/features/getting_started/index.js
+++ b/app/javascript/mastodon/features/getting_started/index.js
@@ -51,7 +51,7 @@ class GettingStarted extends ImmutablePureComponent {
           <ColumnLink icon='users' hideOnMobile={true} text={intl.formatMessage(messages.community_timeline)} to='/timelines/public/local' />
           <ColumnLink icon='nico' hideOnMobile={false} text='ニコニコ形式' href='/nicomment' external={true} />
           <ColumnLink icon='globe' hideOnMobile={true} text={intl.formatMessage(messages.public_timeline)} to='/timelines/public' />
-          <ColumnLink icon='star' text={intl.formatMessage(messages.favourites)} to='/favourites' />
+          <ColumnLink icon='nicoru--column' text={intl.formatMessage(messages.favourites)} to='/favourites' />
           {followRequests}
           <ColumnLink icon='volume-off' text={intl.formatMessage(messages.mutes)} to='/mutes' />
           <ColumnLink icon='ban' text={intl.formatMessage(messages.blocks)} to='/blocks' />


### PR DESCRIPTION
I found to not "nicoru-nized" element, where icon of column "ニコったリスト" in page "/web/getting-started" yet.
This pull-request is fix that.

Best regards :nicoru:.

---

"/web/getting-started"の「ニコったリスト」のアイコンがニコる化されていなかったので、それを修正するコミットです。
ご査収ください。