### PR TITLE
Support nm videos on nicolink

### DIFF
--- a/app/models/nico_link.rb
+++ b/app/models/nico_link.rb
@@ -3,7 +3,7 @@
 class NicoLink
   BASE_URI = URI.parse('https://nico.ms')
 
-  VIDEO_TYPES = %w(sm so).freeze
+  VIDEO_TYPES = %w(sm so nm).freeze
   LIVE_TYPES  = %w(lv).freeze
   TEMPORAL_TYPES = VIDEO_TYPES + LIVE_TYPES
 

--- a/spec/models/nico_link_spec.rb
+++ b/spec/models/nico_link_spec.rb
@@ -43,6 +43,9 @@ RSpec.describe NicoLink, type: :model do
 
         expect(subject.match('sm9')).to_not be_nil
         expect(subject.match('sm0009')).to_not be_nil
+
+        expect(subject.match('nm9')).to_not be_nil
+        expect(subject.match('nm0009')).to_not be_nil
       end
 
       it 'matches nicolinks within Japanese text' do
@@ -57,6 +60,10 @@ RSpec.describe NicoLink, type: :model do
         expect(subject.match('このsm9が好き')).to_not be_nil
         expect(subject.match('つsm90923は観たこと無いな')).to_not be_nil
         expect(subject.match('あsm9９')).to_not be_nil
+
+        expect(subject.match('このnm9が好き')).to_not be_nil
+        expect(subject.match('つnm90923は観たこと無いな')).to_not be_nil
+        expect(subject.match('あnm9９')).to_not be_nil
       end
     end
 


### PR DESCRIPTION
Currently implementation can't follow up `nm0000` video ids. This PR will resolve that an issue.

@masarakki Please review this :nicoru: