### PR TITLE
:cherries: 管理者からのお知らせ機能をアイマストドンから移植

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -10,6 +10,7 @@ module Admin
       site_extended_description
       open_registrations
       closed_registrations_message
+      admin_announcement
     ).freeze
     BOOLEAN_SETTINGS = %w(open_registrations).freeze
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -9,6 +9,7 @@ class HomeController < ApplicationController
     @web_settings           = Web::Setting.find_by(user: current_user)&.data || {}
     @admin                  = Account.find_local(Setting.site_contact_username)
     @streaming_api_base_url = Rails.configuration.x.streaming_api_base_url
+    @admin_announcement     = Setting.find_by(var: 'admin_announcement')&.value || ''
   end
 
   private

--- a/app/javascript/mastodon/features/compose/components/admin_announcements.js
+++ b/app/javascript/mastodon/features/compose/components/admin_announcements.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class AdminAnnouncements extends React.PureComponent {
+
+  static propTypes = {
+    settings: PropTypes.string,
+  };
+
+  render () {
+    const { settings } = this.props;
+
+    if (settings.length === 0) {
+      return null;
+    }
+    return (
+      <ul className='announcements'>
+        <li>
+          <div className='announcements__admin'>
+            <p dangerouslySetInnerHTML={{ __html: settings }} />
+          </div>
+        </li>
+      </ul>
+    );
+  }
+
+};
+
+AdminAnnouncements.propTypes = {
+  settings: PropTypes.string,
+};
+
+export default AdminAnnouncements;

--- a/app/javascript/mastodon/features/compose/containers/admin_announcements_container.js
+++ b/app/javascript/mastodon/features/compose/containers/admin_announcements_container.js
@@ -1,0 +1,10 @@
+import { connect } from 'react-redux';
+import AdminAnnouncements from '../components/admin_announcements';
+
+const mapStateToProps = (state) => {
+  return {
+    settings: state.getIn(['meta', 'admin_announcement']),
+  };
+};
+
+export default connect(mapStateToProps)(AdminAnnouncements);

--- a/app/javascript/mastodon/features/compose/index.js
+++ b/app/javascript/mastodon/features/compose/index.js
@@ -13,6 +13,7 @@ import Motion from 'react-motion/lib/Motion';
 import spring from 'react-motion/lib/spring';
 import SearchResultsContainer from './containers/search_results_container';
 import AnnouncementsContainer from './containers/announcements_container';
+import AdminAnnouncementsContainer from './containers/admin_announcements_container';
 
 const messages = defineMessages({
   start: { id: 'getting_started.heading', defaultMessage: 'Getting started' },
@@ -70,6 +71,7 @@ export default class Compose extends React.PureComponent {
 
         <div className='drawer__pager'>
           <div className='drawer__inner'>
+            <AdminAnnouncementsContainer />
             <NavigationContainer />
             <ConnectAccountContainer />
             <ComposeFormContainer />

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -2846,6 +2846,32 @@ button.icon-button.active i.fa-retweet {
   }
 }
 
+.announcements {
+  padding: 10px;
+
+  li {
+    display: flex;
+    padding: 10px;
+    color: $ui-base-color;
+    background: darken($white, 10%);
+    border-radius: 4px;
+
+    & + li {
+      margin-top: 10px;
+    }
+  }
+}
+
+.announcements__admin {
+  width: 100%;
+  position: relative;
+
+  p {
+    padding: 0 5px;
+    font-size: 14px;
+  }
+}
+
 .announcements__icon {
   flex: 0 0 auto;
   display: inline-block;

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -54,5 +54,13 @@
           @settings['closed_registrations_message'].value,
           rows: 8
 
+      %tr
+        %td
+          %strong= t('admin.settings.admin_announcement.title')
+          %p= t('admin.settings.admin_announcement.desc_html')
+        %td= text_area_tag :admin_announcement,
+          @settings['admin_announcement'].value,
+          rows: 8
+
   .simple_form.actions
     = button_tag t('generic.save_changes'), type: :submit, class: :btn

--- a/app/views/api/v1/instances/show.rabl
+++ b/app/views/api/v1/instances/show.rabl
@@ -3,6 +3,7 @@ object false
 node(:uri)         { site_hostname }
 node(:title)       { Setting.site_title }
 node(:description) { Setting.site_description }
+node(:announcement) { Setting.admin_announcement }
 node(:email)       { Setting.site_contact_email }
 node(:version)     { Mastodon::Version.to_s }
 node :urls do

--- a/app/views/home/initial_state.json.rabl
+++ b/app/views/home/initial_state.json.rabl
@@ -11,6 +11,7 @@ node(:meta) do
     boost_modal: current_account.user.setting_boost_modal,
     delete_modal: current_account.user.setting_delete_modal,
     auto_play_gif: current_account.user.setting_auto_play_gif,
+    admin_announcement: @admin_announcement,
   }
 end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,6 +164,9 @@ en:
       unresolved: Unresolved
       view: View
     settings:
+      admin_announcement:
+        desc_html: Displayed on frontpage.<br>You can use HTML tags
+        title: Administrator announcement
       contact_information:
         email: Enter a public e-mail address
         label: Contact information

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -164,6 +164,9 @@ ja:
       unresolved: 未解決
       view: 表示
     settings:
+      admin_announcement:
+        desc_html: トップページの投稿メニューの上に管理者メッセージが表示されます。<br>HTMLタグが利用可能です。
+        title: 管理者からのメッセージ
       contact_information:
         email: 公開するメールアドレスを入力
         label: 連絡先情報

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,6 +15,7 @@ defaults: &defaults
   open_registrations: true
   closed_registrations_message: ''
   open_deletion: true
+  admin_announcement: ''
   boost_modal: false
   auto_play_gif: true
   delete_modal: true


### PR DESCRIPTION
管理者からのお知らせを管理画面から入力、表示できるadmin_announcementコンポーネントを輸入しました

入力がある場合には投稿欄の上に表示され、ない場合には要素自体が表示されません
またapi/v1/instanceのjson内、announcementキーでも取得することができます

入力|管理画面|ホーム画面|api/v1/instance
 ------------- | ------------- | ------------- | -------------
有|![2017-08-03-141343_1380x1362_scrot](https://user-images.githubusercontent.com/24884114/28907173-b51951c2-7857-11e7-8343-b5f8c6599c72.png)|![2017-08-03-141346_1380x1362_scrot](https://user-images.githubusercontent.com/24884114/28907231-fd1e00a8-7857-11e7-8f09-bd2336cc8ade.png)|![2017-08-03-143348_562x452_scrot](https://user-images.githubusercontent.com/24884114/28907371-d529669a-7858-11e7-919c-dd04c4b725fa.png)
無|![2017-08-03-141400_1380x1362_scrot](https://user-images.githubusercontent.com/24884114/28907235-fd4890a2-7857-11e7-8715-b43b0b5a36e2.png)|![2017-08-03-141406_1380x1362_scrot](https://user-images.githubusercontent.com/24884114/28907234-fd487112-7857-11e7-9453-05efe9f00f16.png)|![2017-08-03-143323_562x452_scrot](https://user-images.githubusercontent.com/24884114/28907374-dc79b4cc-7858-11e7-9f9c-b8fbc0fed8ed.png)
