### PR TITLE
Enquete mini fix

### DIFF
--- a/app/javascript/mastodon/actions/enquetes.js
+++ b/app/javascript/mastodon/actions/enquetes.js
@@ -31,7 +31,7 @@ export function vote(status_id, item_index){
         dispatch(voteSuccess(status_id, item_index));
       }
     }).catch(error => {
-      throw error;
+      console.error(error);
     });
   };
 };

--- a/app/javascript/styles/enquete/enquete.scss
+++ b/app/javascript/styles/enquete/enquete.scss
@@ -29,6 +29,7 @@ $item-font-size: 12px;
         border: 0;
         outline: 0;
         border-radius: 2px;
+        height:36px;
 
         &:focus {
             outline: 0;


### PR DESCRIPTION
# 修正1
app/javascript/mastodon/actions/enquetes.js
```
Mastodonではconsole.logはESLintのルールで書かないよう警告表示されますが、
console.errorは許容されています。
またPromiseの中でエラーをthrowしてもPromiseの内側で握り潰されてしまうので注意が必要です。
```
https://ykzts.technology/users/ykzts/updates/65
 - console.errorは使ってもよいとのことなので、そちらに変更
 - 本当はエラーを受け取ったらvoteFailed(存在しない)のアクションをdispatchしてユーザにエラーを見せたほうがいい(また、voteControllerは投票できなくてもjsonで返すだけで、HTTPステータスコードは200を返すと思うのでそこもオカシイ)

# 修正2
app/javascript/styles/enquete/enquete.scss
 - input要素の高さが指定されておらず、スマートフォンから見た場合に要素が一部隠れてしまうことがあったので修正

| 修正前 | 修正後 |
| ------ | ------ |
| <img width="330" alt="2017-08-25 14 28 54" src="https://user-images.githubusercontent.com/4346679/29701438-a3cf9b6e-89a6-11e7-9980-99e6ce7558a4.png"> | <img width="323" alt="2017-08-25 15 03 40" src="https://user-images.githubusercontent.com/4346679/29701441-aa4b733c-89a6-11e7-86db-5918a43a636d.png"> |
| <img width="330" alt="2017-08-25 14 28 45" src="https://user-images.githubusercontent.com/4346679/29701738-91a6ec38-89a8-11e7-9fc0-6e565bbbd318.png"> | <img width="330" alt="2017-08-25 14 43 46" src="https://user-images.githubusercontent.com/4346679/29701742-98a15ae6-89a8-11e7-9b2c-4899b04bfd7b.png"> |
PCは変化ありません