### PR TITLE
Fix redirect path with niconico login

### DIFF
--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -11,7 +11,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       end
 
       if current_user
-        redirect_to root_path
+        redirect_to after_sign_in_path_for(current_user)
       else
         redirect_to new_user_registration_path
       end


### PR DESCRIPTION
以下の画面を開く際に非ログインだった場合、
「niconicoアカウントでログイン」を押すと↓の画面に戻れなくなる不具合の修正です。

<img width="447" alt="2017-09-04 1 35 21" src="https://user-images.githubusercontent.com/1131422/30004862-6242c262-9111-11e7-811b-15b7fc38a974.png">
