### PR TITLE
change default columns order

### DIFF
--- a/app/javascript/mastodon/reducers/settings.js
+++ b/app/javascript/mastodon/reducers/settings.js
@@ -56,8 +56,9 @@ const initialState = ImmutableMap({
 
 const defaultColumns = fromJS([
   { id: 'COMPOSE', uuid: uuid(), params: {} },
-  { id: 'HOME', uuid: uuid(), params: {} },
+  { id: 'COMMUNITY', uuid: uuid(), params: {} },
   { id: 'NOTIFICATIONS', uuid: uuid(), params: {} },
+  { id: 'HOME', uuid: uuid(), params: {} },
 ]);
 
 const hydrate = (state, settings) => state.mergeDeep(settings).update('columns', (val = defaultColumns) => val);


### PR DESCRIPTION
新規登録時のカラムのデフォルト並び順を
- 投稿欄
- ローカルTL
- 通知
- ホーム
- スタートメニュー

に変更します。

カラムの並び順を自分でカスタマイズしていない既存ユーザは、これによってカラムの並び順が変更されます。