### PR TITLE
Fix argument shortage

### DIFF
--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -172,7 +172,7 @@ export default class UI extends React.PureComponent {
 
   componentDidUpdate (prevProps) {
     if (![this.props.location.pathname, '/'].includes(prevProps.location.pathname)) {
-      this.columnsAreaNode.handleChildrenContentChange();
+      this.columnsAreaNode.handleChildrenContentChange(prevProps);
     }
   }
 


### PR DESCRIPTION
トゥート詳細を開くと以下のエラーが発生します。
<img width="753" alt="2017-09-28 18 29 13" src="https://user-images.githubusercontent.com/17416874/30959401-f9a7a75e-a47a-11e7-95de-db8c874ed332.png">
`columns_area.js` で定義されている `handleChildrenContentChange()` にある引数を
`ui/index.js` で渡していないことによるエラーです。