### PR TITLE
Fix profile emoji suggestion

### DIFF
--- a/app/javascript/mastodon/components/autosuggest_textarea.js
+++ b/app/javascript/mastodon/components/autosuggest_textarea.js
@@ -35,8 +35,8 @@ const textAtCursorMatchesToken = (str, caretPosition) => {
 const textAtCursorMatchesProfileEmojiToken = (str, caretPosition) => {
   let word;
 
-  let left  = str.slice(0, caretPosition).search(/:\S+$/);
-  let right = str.slice(caretPosition).search(/\s/);
+  let left  = str.slice(0, caretPosition).search(/:[^:\s]+$/);
+  let right = str.slice(caretPosition).search(/[:\s]/);
   if (left < 0) {
     return [null, null];
   }

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -188,7 +188,10 @@ const setProfileEmojiSuggestions = (state, accounts, token) => {
 
 const insertProfileEmojiSuggestion = (state, position, token, completion) => {
   return state.withMutations(map => {
-    map.update('text', oldText => `${oldText.slice(0, position)}${completion}:${oldText.slice(position + token.length + 1)}`);
+    const oldText = map.get('text');
+    const tail = (oldText[position + token.length + 1] === ':'? '' : ':')
+               + oldText.slice(position + token.length + 1);
+    map.update('text', oldText => `${oldText.slice(0, position)}${completion}${tail}`);
     map.set('profile_emoji_suggestion_token', null);
     map.update('profile_emoji_suggestions', ImmutableList(), list => list.clear());
     map.set('focusDate', new Date());


### PR DESCRIPTION
Profile emojiサジェスト周りの動作バグを修正します。

### 修正バグ例

- 入力欄`:@foo:`の状態からスペースを空けずに続けて`:@bar:`をサジェスト入力しようとすると、`:@foo:`が消える
- 入力欄`:@foo::@bar:`の状態から`foo`を書き換えようとするとサジェストが正しく表示されない