### PR TITLE
Fix broken display's ellipse(for long display name users)

### DIFF
--- a/app/javascript/styles/nico/profile_emoji.scss
+++ b/app/javascript/styles/nico/profile_emoji.scss
@@ -1,6 +1,5 @@
 // Overrides 'overflow: hidden' due to display expanded emojis
 .status__content,
-.display-name,
 .display-name__html,
 .detailed-status .detailed-status__display-name,
 .account-authorize .detailed-status__display-name,


### PR DESCRIPTION
長いユーザー名の時、「…」での省略表記になる部分がはみ出していた問題を修正しました。

Please review @masarakki 