### PR TITLE
本文に空行が連続して2行以上あった場合、その空行以降がハイライトされなかった問題を修正

### DIFF
--- a/app/javascript/mastodon/actions/highlight_keywords.js
+++ b/app/javascript/mastodon/actions/highlight_keywords.js
@@ -66,7 +66,7 @@ export function checkHighlightNotification(status) {
       } else {
         contentDom.innerHTML = addHighlight(status.content, highlightKeywords);
       }
-      spoilerDom.innerHTML = addHighlight(`<p>${status.spoiler_text}</p>`, highlightKeywords);
+      spoilerDom.innerHTML = addHighlight(status.get('spoilerHtml'), highlightKeywords);
       if (contentDom.getElementsByClassName('highlight').length + spoilerDom.getElementsByClassName('highlight').length > 0 ) {
         sendNotificationFlag = true;
       }
@@ -115,7 +115,7 @@ export function addHighlight (text, keywords) {
     var dom = document.createElement('div');
     dom.innerHTML = text;
 
-    replaceHighlight(reg, dom.firstChild);
+    replaceHighlight(reg, dom);
 
     return dom.innerHTML;
   } else {

--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -134,7 +134,7 @@ export default class StatusContent extends React.PureComponent {
 
     const hidden = this.props.onExpandedToggle ? !this.props.expanded : this.state.hidden;
     const content = { __html: addHighlight(status.get('contentHtml'), this.props.highlightKeywords) };
-    const spoilerContent = { __html: addHighlight(`<p>${status.get('spoilerHtml')}</p>`, this.props.highlightKeywords) };
+    const spoilerContent = { __html: addHighlight(status.get('spoilerHtml'), this.props.highlightKeywords) };
     const directionStyle = { direction: 'ltr' };
     const classNames = classnames('status__content', {
       'status__content--with-action': this.props.onClick && this.context.router,


### PR DESCRIPTION
If two or more empty lines are present, the after of those empty lines was not be highlighted.

|before|after|
| --------------- | -------------------- |
|![image](https://user-images.githubusercontent.com/24884114/31052838-062ad202-a6ca-11e7-887f-71f633e2e259.png)|![image](https://user-images.githubusercontent.com/24884114/31052745-540b68bc-a6c8-11e7-8630-ce1aa9e0f133.png)

