### PR TITLE
fix tuforial black modal sizes

### DIFF
--- a/app/javascript/mastodon/features/tutorial/components/tutorial_contents.js
+++ b/app/javascript/mastodon/features/tutorial/components/tutorial_contents.js
@@ -111,27 +111,27 @@ const adjustBackSizePosition = (targetPosition) => {
   document.querySelector('.tutorial-back-top').style.left = targetPosition.left + 'px';
 
   // right
-  document.querySelector('.tutorial-back-right').style.width = '2000px';
-  document.querySelector('.tutorial-back-right').style.height = '2000px';
+  document.querySelector('.tutorial-back-right').style.width = window.parent.screen.width + 'px';
+  document.querySelector('.tutorial-back-right').style.height = window.parent.screen.height + 'px';
   document.querySelector('.tutorial-back-right').style.top = 0;
   document.querySelector('.tutorial-back-right').style.left = (targetPosition.left + targetPosition.width) + 'px';
 
   // bottom
   document.querySelector('.tutorial-back-bottom').style.width = targetPosition.width + 'px';
-  document.querySelector('.tutorial-back-bottom').style.height = isColumn ? 0 : '2000px';
+  document.querySelector('.tutorial-back-bottom').style.height = isColumn ? 0 : window.parent.screen.height + 'px';
   document.querySelector('.tutorial-back-bottom').style.top = targetPosition.bottom + 'px';
   document.querySelector('.tutorial-back-bottom').style.left = targetPosition.left + 'px';
 
   // left
   document.querySelector('.tutorial-back-left').style.width = targetPosition.left + 'px';
-  document.querySelector('.tutorial-back-left').style.height = '2000px';
+  document.querySelector('.tutorial-back-left').style.height = window.parent.screen.height + 'px';
   document.querySelector('.tutorial-back-left').style.top = 0;
   document.querySelector('.tutorial-back-left').style.right = targetPosition.left + 'px';
 };
 
 const adjustWindowPosition = (target, newProp) => {
   let windowLeft = document.querySelector('.columns-area').scrollLeft;
-  let windowRight = windowLeft + window.innerWidth;
+  let windowRight = windowLeft + window.parent.screen.width;
   let balloonInfo = document.querySelectorAll('.tutorial-contents')[newProp.nowPage - 1].getBoundingClientRect();
   let balloonLeft = balloonInfo.left;
   let balloonRight = balloonLeft + balloonInfo.width;


### PR DESCRIPTION
チュートリアルの背景を暗くするモーダルの幅が2000px決め打ちだったため、4kディスプレイを使用すると暗くならない部分が出てしまっていた問題を修正しました。

`window.innerWidth` ではなく `window.parent.screen.width` を使用したのは、当該要素の幅の代入が表示時のみのため、画面の左右半分等にスナップした状態で表示し、全画面にすると当該要素がリサイズされず、暗くならない部分が出てしまうためです。

もっと正しく実装するならば `window.innerWidth` にonChangeイベントハンドラを付けてそこで処理するべきでしょうが、そこまでの実装コストは過剰かと思いました。

|before|after|
|--|--|
|![image](https://user-images.githubusercontent.com/24884114/31112383-55f9aa76-a84e-11e7-8d81-2c39703379ae.png)|![image](https://user-images.githubusercontent.com/24884114/31112391-59abcd7a-a84e-11e7-901d-5c98bb396b51.png)|