### PR TITLE
Update source code repository url

### DIFF
--- a/app/javascript/mastodon/features/getting_started/index.js
+++ b/app/javascript/mastodon/features/getting_started/index.js
@@ -111,7 +111,7 @@ export default class GettingStarted extends ImmutablePureComponent {
               <FormattedMessage
                 id='getting_started.open_source_notice'
                 defaultMessage='Mastodon is open source software. You can contribute or report issues on GitHub at {github}.'
-                values={{ github: <a href='https://github.com/tootsuite/mastodon' rel='noopener' target='_blank'>tootsuite/mastodon</a> }}
+                values={{ github: <a href='https://github.com/dwango/mastodon' rel='noopener' target='_blank'>dwango/mastodon</a> }}
               />
             </p>
           </div>

--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -33,12 +33,12 @@ module Mastodon
     end
 
     def source_base_url
-      'https://github.com/tootsuite/mastodon'
+      'https://github.com/dwango/mastodon'
     end
 
     # specify git tag or commit hash here
     def source_tag
-      nil
+      'friends.nico'
     end
 
     def source_url


### PR DESCRIPTION
ソースコードの URL 変えてなかったのが気になったのですが変えないことに決まってたらすみません＞＜
pawoo では pixiv レポジトリになってます。

以下のような場所が変わります。

- `/web/getting-started` の右下

![image](https://user-images.githubusercontent.com/139241/31317314-87f2e784-ac79-11e7-8dff-91920727df04.png)

- `/about` , `/about/more` ページの右下

![image](https://user-images.githubusercontent.com/139241/31317336-ce4162ba-ac79-11e7-8e10-bf83016a98ab.png)

