### PR TITLE
ProfileEmoji changed to not use gif

### DIFF
--- a/app/lib/friends/profile_emoji_model.rb
+++ b/app/lib/friends/profile_emoji_model.rb
@@ -6,6 +6,13 @@ module Friends
 
     IMAGE_MIME_TYPES = AccountAvatar::IMAGE_MIME_TYPES
 
+    Image = Struct.new(:source) do
+      def url(type = :original)
+        type = :original unless source.content_type == 'image/gif'
+        source.url(type)
+      end
+    end
+
     def profile_emoji
       avatar
     end

--- a/app/serializers/rest/profile_emoji_serializer.rb
+++ b/app/serializers/rest/profile_emoji_serializer.rb
@@ -8,7 +8,7 @@ class REST::ProfileEmojiSerializer < ActiveModel::Serializer
   end
 
   def url
-    full_asset_url(object.image.url(:original))
+    full_asset_url(object.image.url(:static))
   end
 
   def account_url


### PR DESCRIPTION
ProfileEmoji changed to not use gif.
If you have decided to use gif, please reject this pr.

ref https://github.com/tootsuite/mastodon/pull/5315/files#diff-abda93c770af9d5e1e76bc9cd31ab7e5R8