### PR TITLE
getting-startedメニューのscssを修正

### DIFF
--- a/app/javascript/styles/nico.scss
+++ b/app/javascript/styles/nico.scss
@@ -8,4 +8,5 @@
 @import 'nico/tutorial';
 @import 'nico/profile_emoji';
 @import 'nico/highlight';
+@import 'nico/getting-started';
 @import 'nico/enquete'

--- a/app/javascript/styles/nico/getting-started.scss
+++ b/app/javascript/styles/nico/getting-started.scss
@@ -1,0 +1,11 @@
+.column-link {
+    padding: 12px 15px;
+}
+
+.getting-started {
+    padding-bottom: 200px;
+}
+
+.getting-started__wrapper {
+    max-height: 60vh;
+}


### PR DESCRIPTION
friends.nicoのgetting-startedメニューは項目が多く、見づらいと思ったため項目の縦方向のpaddingを少し減らしました。
また、スマートフォンで表示した場合に項目が多すぎてテレビちゃんが見えなくなってしまっていたため、max-heightを設定してテレビちゃんが見えるように修正しました

## PC表示
|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/24884114/32821091-0395e9aa-ca15-11e7-90ed-d0672c30579e.png)|![image](https://user-images.githubusercontent.com/24884114/32821092-059f129e-ca15-11e7-898d-51ab4a4adc7c.png)|

## スマホ表示(chromeによる疑似表示)
|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/24884114/32821126-3087d540-ca15-11e7-9512-69837f583d99.png)|![image](https://user-images.githubusercontent.com/24884114/32821138-3f442e30-ca15-11e7-96aa-30e47a6749f5.png)|
