### PR TITLE
Enable to show unlisted tagged toots on the hashtag timeline

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -69,6 +69,7 @@ class Status < ApplicationRecord
   scope :without_replies, -> { where('statuses.reply = FALSE OR statuses.in_reply_to_account_id = statuses.account_id') }
   scope :without_reblogs, -> { where('statuses.reblog_of_id IS NULL') }
   scope :with_public_visibility, -> { where(visibility: :public) }
+  scope :with_public_or_unlisted_visibility, -> { where(visibility: [:public, :unlisted]) }
   scope :tagged_with, ->(tag) { joins(:statuses_tags).where(statuses_tags: { tag_id: tag }) }
   scope :excluding_silenced_accounts, -> { left_outer_joins(:account).where(accounts: { silenced: false }) }
   scope :including_silenced_accounts, -> { left_outer_joins(:account).where(accounts: { silenced: true }) }
@@ -162,7 +163,8 @@ class Status < ApplicationRecord
     end
 
     def as_tag_timeline(tag, account = nil, local_only = false)
-      query = timeline_scope(local_only).tagged_with(tag)
+      where(visibility: [:public, :unlisted])
+      query = timeline_scope(local_only, false).tagged_with(tag)
 
       apply_timeline_filters(query, account, local_only)
     end
@@ -227,11 +229,15 @@ class Status < ApplicationRecord
 
     private
 
-    def timeline_scope(local_only = false)
+    def timeline_scope(local_only = false, public_only = true)
       starting_scope = local_only ? Status.local : Status
-      starting_scope
-        .with_public_visibility
-        .without_reblogs
+      starting_scope = starting_scope.without_reblogs
+
+      if public_only
+        starting_scope = starting_scope.with_public_visibility
+      else
+        starting_scope = starting_scope.with_public_or_unlisted_visibility
+      end
     end
 
     def apply_timeline_filters(query, account, local_only)

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -16,12 +16,12 @@ class FanOutOnWriteService < BaseService
       deliver_to_followers(status)
     end
 
-    return if status.account.silenced? || !status.public_visibility? || status.reblog?
+    return if status.account.silenced? || !status.public_visibility? && !status.unlisted_visibility? || status.reblog?
 
     render_anonymous_payload(status)
     deliver_to_hashtags(status)
 
-    return if status.reply? && status.in_reply_to_account_id != status.account_id
+    return if status.reply? && status.in_reply_to_account_id != status.account_id || status.unlisted_visibility?
 
     deliver_to_public(status)
   end


### PR DESCRIPTION
未収載かつタグ付きのtootを、そのタグのTLに表示するようにします。

![image](https://user-images.githubusercontent.com/24884114/32936130-59b91562-cbb6-11e7-8b48-2c281a49bf71.png)


* Enable to show unlisted tagged toots on the hashtag timeline

* Add missing conditional expression

* Correcting visibility filtering