### PR TITLE
detailed_statusの動画リンククリック時の挙動修正

### DIFF
--- a/app/javascript/mastodon/features/status/components/detailed_status.js
+++ b/app/javascript/mastodon/features/status/components/detailed_status.js
@@ -24,6 +24,7 @@ export default class DetailedStatus extends ImmutablePureComponent {
     onOpenVideo: PropTypes.func.isRequired,
     autoPlayGif: PropTypes.bool,
     highlightKeywords: ImmutablePropTypes.map.isRequired,
+    onNiconicoVideoLinkClick: PropTypes.func,
   };
 
   handleAccountClick = (e) => {
@@ -107,7 +108,7 @@ export default class DetailedStatus extends ImmutablePureComponent {
           <DisplayName account={status.get('account')} />
         </a>
 
-        <StatusContent status={status} highlightKeywords={this.props.highlightKeywords} />
+        <StatusContent status={status} highlightKeywords={this.props.highlightKeywords} onNiconicoVideoLinkClick={this.props.onNiconicoVideoLinkClick} />
 
         {media}
 

--- a/app/javascript/mastodon/features/status/index.js
+++ b/app/javascript/mastodon/features/status/index.js
@@ -29,6 +29,7 @@ import { openModal } from '../../actions/modal';
 import { defineMessages, injectIntl } from 'react-intl';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { HotKeys } from 'react-hotkeys';
+import { openNiconicoVideoLink } from '../../actions/nicovideo_player';
 
 const messages = defineMessages({
   deleteConfirm: { id: 'confirmations.delete.confirm', defaultMessage: 'Delete' },
@@ -256,10 +257,13 @@ export default class Status extends ImmutablePureComponent {
     }
   }
 
+  onNiconicoVideoLinkClick = videoId => {
+    this.props.dispatch(openNiconicoVideoLink(videoId));
+  }
+
   render () {
     let ancestors, descendants;
     const { status, ancestorsIds, descendantsIds, me, autoPlayGif, highlightKeywords } = this.props;
-
     if (status === null) {
       return (
         <Column>
@@ -304,6 +308,7 @@ export default class Status extends ImmutablePureComponent {
                   onOpenVideo={this.handleOpenVideo}
                   onOpenMedia={this.handleOpenMedia}
                   highlightKeywords={highlightKeywords}
+                  onNiconicoVideoLinkClick={this.onNiconicoVideoLinkClick}
                 />
 
                 <ActionBar


### PR DESCRIPTION
投稿の詳細（detailed_status）の動画リンクをクリックするとエラーが出てしまっていたので修正しました。
よろしくお願いします。
![screen shot 2017-11-20 at 21 45 25](https://user-images.githubusercontent.com/22878067/33019234-d0dfa72c-ce3c-11e7-8472-2ce120213247.png)
