### PR TITLE
Stoplight::Error::RedLightをerribitで送信しないように変更

### DIFF
--- a/config/initializers/errbit.rb
+++ b/config/initializers/errbit.rb
@@ -3,7 +3,7 @@ unless ENV['DISABLE_PROJECT_ID'].present?
   require 'rake'
   require 'airbrake'
 
-  IGNORE_EXCEPTIONS = %w(Mastodon::UnexpectedResponseError OpenSSL::SSL::SSLError)
+  IGNORE_EXCEPTIONS = %w(Mastodon::UnexpectedResponseError OpenSSL::SSL::SSLError Stoplight::Error::RedLight)
 
   Airbrake.configure do |config|
     config.project_key = ENV['ERRBIT_PROJECT_KEY']


### PR DESCRIPTION
- リモートインスタンスへのpushが一定回数失敗した場合に使われる例外クラスのため