### PR TITLE
Increase maxlength of account's note

### DIFF
--- a/app/views/settings/profiles/show.html.haml
+++ b/app/views/settings/profiles/show.html.haml
@@ -7,7 +7,7 @@
   .fields-row
     .fields-row__column.fields-group.fields-row__column-6
       = f.input :display_name, wrapper: :with_label, input_html: { maxlength: 30 }, hint: false
-      = f.input :note, wrapper: :with_label, input_html: { maxlength: 160 }, hint: false
+      = f.input :note, wrapper: :with_label, input_html: { maxlength: 1000 }, hint: false
 
   .fields-row
     .fields-row__column.fields-row__column-6


### PR DESCRIPTION
プロフィールの文字数制限が HTML 側でかかってしまっていたので修正しました。

Please review: @masarakki @takayamaki 

see: https://github.com/dwango/mastodon/blob/friends.nico/app/models/account.rb#L78