### PR TITLE
Disable profile emoji expantion

### DIFF
--- a/app/javascript/styles/nico/profile_emoji.scss
+++ b/app/javascript/styles/nico/profile_emoji.scss
@@ -1,3 +1,8 @@
+/**
+ * DO NOT EXPAND PROFILE EMOJI.
+ * this feature conflict with https://github.com/tootsuite/mastodon/pull/8205/files
+ * Uncomment this section, If you have any great solution.
+
 // Overrides 'overflow: hidden' due to display expanded emojis
 .status__content,
 .display-name__html,
@@ -23,3 +28,5 @@
     }
   }
 }
+
+ */


### PR DESCRIPTION
Fix a bug in a toot with collapsed(automated).
ref: https://github.com/tootsuite/mastodon/pull/8205/files

friends.nico:

<img width="341" alt="2018-12-25 21-13-31" src="https://user-images.githubusercontent.com/29084/50422085-f6764a80-0889-11e9-9ec4-77852eaf5d67.png">

Mastodon.social:

<img width="341" alt="2018-12-25 21-13-56" src="https://user-images.githubusercontent.com/29084/50422086-04c46680-088a-11e9-812c-5e9f72580432.png">

Test text by : [くぅ～疲れましたw](https://dic.pixiv.net/a/%E3%81%8F%E3%81%85%EF%BD%9E%E7%96%B2%E3%82%8C%E3%81%BE%E3%81%97%E3%81%9Fw)
