### PR TITLE
投稿詳細ページでのニコるの色修正 / ←により不要になったnicoru-detailedの削除

### DIFF
--- a/app/javascript/images/nicoru-detailed.svg
+++ b/app/javascript/images/nicoru-detailed.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-32 -32 64 64" fill="none" stroke="#9BAEC8" stroke-linecap="round"><circle r="30" stroke-width="4"/><path d="M-8-18v12m0,12v6m17,0v-6m0-14v-8" stroke-width="8"/><path d="M-2,19a7,7 0 0 1-7-7h2a7,7 0 0 0 7,7h1a7,7 0 0 0 7-7h2a7,7 0 0 1-7,7z" stroke-width="6"/></svg>

--- a/app/javascript/mastodon/nicoru.js
+++ b/app/javascript/mastodon/nicoru.js
@@ -2,5 +2,4 @@ export default {
   main: require('../images/nicoru.svg'),
   column: require('../images/nicoru-column.svg'),
   status: require('../images/nicoru-status.svg'),
-  detailed: require('../images/nicoru-detailed.svg'),
 };

--- a/app/javascript/styles/nico/nicoru.scss
+++ b/app/javascript/styles/nico/nicoru.scss
@@ -56,10 +56,4 @@ button.icon-button.active i.fa-nicoru {
     @extend .fa-nicoru;
     background-image: url('../images/nicoru-status.svg');
   }
-
-  &--detailed {
-    @extend .fa-nicoru;
-    background-image: url('../images/nicoru-detailed.svg');
-    vertical-align: middle;
-  }
 }

--- a/app/views/stream_entries/_detailed_status.html.haml
+++ b/app/views/stream_entries/_detailed_status.html.haml
@@ -61,7 +61,7 @@
         = " "
     ·
     = link_to remote_interaction_path(status), class: 'modal-button detailed-status__link' do
-      = fa_icon('nicoru--detailed')
+      = fa_icon('nicoru--status')
       %span.detailed-status__favorites>= number_to_human status.favourites_count, strip_insignificant_zeros: true
       = " "
 


### PR DESCRIPTION
詳細画面用のニコるくんの色を、本家v2.5.0での投稿詳細画面のデザイン変更に追従し、WebUI等で表示される暗めのニコるくん(nicoru-status)と同じ色にします。

|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/6533808/51942985-b80d1600-245b-11e9-86bd-f33c135cdab6.png)|![image](https://user-images.githubusercontent.com/6533808/51942994-bfccba80-245b-11e9-8182-aab6aed500fa.png)|


また、それにあわせて不要になった旧詳細画面用のニコるくん(nicoru-detailed)を削除します。